### PR TITLE
Support for async serialize/deserialize of transferHandler

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -493,7 +493,7 @@ function createProxy<T>(
       })();
       return true;
     },
-    async apply(_target, _thisArg, rawArgumentList) {
+    apply(_target, _thisArg, rawArgumentList) {
       throwIfProxyReleased(isProxyReleased);
       const last = path[path.length - 1];
       if ((last as any) === createEndpoint) {
@@ -505,18 +505,20 @@ function createProxy<T>(
       if (last === "bind") {
         return createProxy(ep, path.slice(0, -1));
       }
-      const [argumentList, transferables] = await processArguments(
-        rawArgumentList
-      );
-      return requestResponseMessage(
-        ep,
-        {
-          type: MessageType.APPLY,
-          path: path.map((p) => p.toString()),
-          argumentList,
-        },
-        transferables
-      ).then(fromWireValue);
+      return (async () => {
+        const [argumentList, transferables] = await processArguments(
+          rawArgumentList
+        );
+        return requestResponseMessage(
+          ep,
+          {
+            type: MessageType.APPLY,
+            path: path.map((p) => p.toString()),
+            argumentList,
+          },
+          transferables
+        ).then(fromWireValue);
+      })();
     },
     async construct(_target, rawArgumentList) {
       throwIfProxyReleased(isProxyReleased);

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -193,14 +193,14 @@ export interface TransferHandler<T, S> {
    * value that can be sent in a message, consisting of structured-cloneable
    * values and/or transferrable objects.
    */
-  serialize(value: T): Promise<[S, Transferable[]]>;
+  serialize(value: T): Promise<[S, Transferable[]]> | [S, Transferable[]];
 
   /**
    * Gets called to deserialize an incoming value that was serialized in the
    * other thread with this transfer handler (known through the name it was
    * registered under).
    */
-  deserialize(value: S): Promise<T>;
+  deserialize(value: S): Promise<T> | T;
 }
 
 /**

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -520,20 +520,22 @@ function createProxy<T>(
         ).then(fromWireValue);
       })();
     },
-    async construct(_target, rawArgumentList) {
+    construct(_target, rawArgumentList) {
       throwIfProxyReleased(isProxyReleased);
-      const [argumentList, transferables] = await processArguments(
-        rawArgumentList
-      );
-      return requestResponseMessage(
-        ep,
-        {
-          type: MessageType.CONSTRUCT,
-          path: path.map((p) => p.toString()),
-          argumentList,
-        },
-        transferables
-      ).then(fromWireValue);
+      return (async () => {
+        const [argumentList, transferables] = await processArguments(
+          rawArgumentList
+        );
+        return requestResponseMessage(
+          ep,
+          {
+            type: MessageType.CONSTRUCT,
+            path: path.map((p) => p.toString()),
+            argumentList,
+          },
+          transferables
+        ).then(fromWireValue);
+      })();
     },
   });
   registerProxy(proxy, ep);

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -357,11 +357,11 @@ async function closureSoICanUseAwait() {
         assert<IsExact<typeof val, unknown>>(true);
         return val instanceof URL;
       },
-      serialize: (url) => {
+      serialize: async (url) => {
         assert<IsExact<typeof url, URL>>(true);
         return [url.href, []];
       },
-      deserialize: (str) => {
+      deserialize: async (str) => {
         assert<IsExact<typeof str, string>>(true);
         return new URL(str);
       },

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -357,11 +357,11 @@ async function closureSoICanUseAwait() {
         assert<IsExact<typeof val, unknown>>(true);
         return val instanceof URL;
       },
-      serialize: async (url) => {
+      serialize: (url) => {
         assert<IsExact<typeof url, URL>>(true);
         return [url.href, []];
       },
-      deserialize: async (str) => {
+      deserialize: (str) => {
         assert<IsExact<typeof str, string>>(true);
         return new URL(str);
       },


### PR DESCRIPTION
# Motivation

Enabled to use async functions for `serialize` and `deserialize` of `transferHandlers` to transfer such as `Blob`.

# Example

```typescript
import * as Comlink from "comlink";

Comlink.transferHandlers.set("blob", {
  canHandle: (obj): obj is Blob => obj instanceof Blob,
  // Enable to use async functions.
  serialize: async (blob: Blob) => [
    { data: await blob.arrayBuffer(), type: blob.type, size: blob.size },
    [],
  ],
  deserialize: async (obj: BlobObject): Promise<Blob> =>
    new Blob([obj.data], { type: obj.type }),
});
```

# Related
https://github.com/GoogleChromeLabs/comlink/issues/646