### PR TITLE
export throw marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemachina/comlink",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "A fork of GoogleChromeLabs/comlink.",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -20,8 +20,7 @@ export const proxyMarker = Symbol("Comlink.proxy");
 export const createEndpoint = Symbol("Comlink.endpoint");
 export const releaseProxy = Symbol("Comlink.releaseProxy");
 export const finalizer = Symbol("Comlink.finalizer");
-
-const throwMarker = Symbol("Comlink.thrown");
+export const throwMarker = Symbol("Comlink.thrown");
 
 /**
  * Interface of values that were marked to be proxied with `comlink.proxy()`.


### PR DESCRIPTION
This change is necessary to override throwTransferHandler ourselves.